### PR TITLE
create more user friendly way to create mod_def.ww3

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -22,7 +22,7 @@ sys.path.append(_LIBDIR)
 from standard_script_setup          import *
 from CIME.buildnml                  import create_namelist_infile, parse_input
 from CIME.case                      import Case
-from CIME.utils                     import expect, run_cmd
+from CIME.utils                     import expect, run_cmd, safe_copy
 from CIME.nmlgen                    import NamelistGenerator
 
 logger = logging.getLogger(__name__)
@@ -234,6 +234,19 @@ def buildnml(case, caseroot, compname):
     rundir = case.get_value("RUNDIR")
     din_loc_root = case.get_value("DIN_LOC_ROOT")
     wav_grid = case.get_value("WAV_GRID")
+
+    # Copy ww3_inp and other needed info to ww3_moddef_dir
+    ww3_moddef_dir = os.path.join(rundir, "ww3_moddef_create")
+    if not os.path.exists(ww3_moddef_dir):
+        os.makedirs(ww3_moddef_dir)
+
+    ww3_msh = case.get_value("WW3_MSH")
+    if ww3_msh != 'unset':
+        safe_copy(ww3_msh, ww3_moddef_dir)
+
+    ww3_grid_inp = case.get_value("WW3_GRID_INP")
+    if ww3_grid_inp != 'unset':
+        shutil.copy(ww3_grid_inp, os.path.join(ww3_moddef_dir, "ww3_grid.inp"))
 
     # If mod_def.ww3 is already in the directory - then use it
     rundir = case.get_value("RUNDIR")

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -43,6 +43,28 @@
     <desc>mod_def file to use</desc>
   </entry>
 
+  <entry id="WW3_GRID_INP">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value grid="_w%wise.tnx1v4p.100k">$DIN_LOC_ROOT/wav/ww3/ww3_grid_inp.wise.tnx1v4p.100k</value>
+    </values>
+    <group>case_comp</group>
+    <file>env_run.xml</file>
+    <desc>mod_def file to use</desc>
+  </entry>
+
+  <entry id="WW3_MSH">
+    <type>char</type>
+    <default_value>unset</default_value>
+    <values>
+      <value grid="_w%wise.tnx1v4p.100k">$DIN_LOC_ROOT/wav/ww3/GLOBAL_100k_with_tnx1v4maskP.msh</value>
+    </values>
+    <group>case_comp</group>
+    <file>env_run.xml</file>
+    <desc>mod_def file to use</desc>
+  </entry>
+
   <help>
     =========================================
     WW naming conventions


### PR DESCRIPTION
- A new directory $RUNDIR/ww3_moddef_create
- Based on new xml variables WW3_MSH and WW3_GRID_INP new files needed by ww3_grid are prestaged into `ww3_moddef_create` as part of preview_namelist
- As part of the build - a ww3_grid executable is created in `ww3_moddef_create`
- Once a new mod_def.ww3 is created, if it is copied into $RUNDIR with the name user_mod_def.ww3 then the scripts will know to copy this to mod_def.ww3 and use it