### PR TITLE
new updated and improved  workflow

### DIFF
--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,9 +1,7 @@
 [ww3dev]
-#tag = ww3_noresm0.0.5
-branch = feature/updated_workflow
+tag = ww3_noresm0.0.6
 protocol = git
-#repo_url = https://github.com/NorESMhub/WW3.git
-repo_url = https://github.com/mvertens/WW3.git
+repo_url = https://github.com/NorESMhub/WW3.git
 local_path = WW3
 required = True
 

--- a/Externals.cfg
+++ b/Externals.cfg
@@ -1,7 +1,9 @@
 [ww3dev]
-tag = ww3_noresm0.0.5
+#tag = ww3_noresm0.0.5
+branch = feature/updated_workflow
 protocol = git
-repo_url = https://github.com/NorESMhub/WW3.git
+#repo_url = https://github.com/NorESMhub/WW3.git
+repo_url = https://github.com/mvertens/WW3.git
 local_path = WW3
 required = True
 

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -3,7 +3,7 @@
 """
 build ww3 library
 """
-import sys, os
+import sys, os, shutil
 
 _CIMEROOT = os.environ.get("CIMEROOT")
 if _CIMEROOT is None:
@@ -66,14 +66,51 @@ def buildlib(bldroot, libroot, case, compname=None):
     s,o,e = run_cmd("make install VERBOSE=1 DESTDIR={}".format(destdir), from_dir=bldroot, verbose=True)
     expect(not s,"ERROR from make output={}, error={}".format(o,e))
 
+    #----------------------------------------------------
+    # Prestage necessary files to rundir
+    #----------------------------------------------------
+    rundir = case.get_value("RUNDIR")
+
+    # Create rundir/ww3_moddef_create
     filename = "ww3_grid"
     item = os.path.join(bldroot, filename)
     if os.path.isfile(item):
-        rundir = case.get_value("RUNDIR")
         ww3_moddef_dir = os.path.join(rundir, "ww3_moddef_create")
         if not os.path.exists(ww3_moddef_dir):
             os.makedirs(ww3_moddef_dir)
         safe_copy(item, ww3_moddef_dir)
+
+    if case.get_value("WW3_MODDEF") == 'unset':
+        # Create output dir ww3_moddef_create if appropriate
+        output_dir = os.path.join(rundir, "ww3_moddef_create")
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+
+        # Copy ww3_inp and other needed info to ww3_moddef_create directory
+        input_dir = case.get_value("WW3_GRID_INP_DIR")
+        files = os.listdir(input_dir)
+        for filename in files:
+            if not os.path.isfile(os.path.join(output_dir, filename)):
+                shutil.copy(os.path.join(input_dir, filename), os.path.join(output_dir, filename))
+
+        # Create mod_def file using ww3_grid and the grid_input files
+        os.chdir(output_dir)
+        os.scandir()
+        os.system("./ww3_grid > mod_def.ww3.log")
+
+        # Copy mod_def.ww3 to $RUNDIR
+        shutil.move("mod_def.ww3", os.path.join(rundir, "mod_def.ww3"))
+        shutil.move("mod_def.ww3.log", os.path.join(rundir, "mod_def.ww3.log"))
+
+    else:
+        # Use mod_def already created 
+        mod_def_in = case.get_value("WW3_MODDEF")
+        if os.path.isfile(mod_def_in):
+            import filecmp
+            if not filecmp.cmp(mod_def_in, os.path.join(rundir, "mod_def.ww3")):
+                shutil.copy(mod_def_in, os.path.join(rundir, "mod_def.ww3"))
+        else:
+            raise RuntimeError("mod_def_in {} does not exist on disk".format(mod_def_in))
 
 def _main_func(args):
     caseroot, libroot, bldroot = parse_input(args)

--- a/cime_config/buildlib
+++ b/cime_config/buildlib
@@ -35,6 +35,7 @@ def buildlib(bldroot, libroot, case, compname=None):
     exe_root = case.get_value("EXEROOT")
     srcpath = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir, "WW3", "model", "src"))
 
+
     # Determine cmake flags
     use_unstruct = case.get_value("WW3_UNSTRUCT")
     sharedpath = os.path.join(case.get_value("COMPILER"), mpilib, strdebug, strthread, "nuopc")
@@ -46,6 +47,14 @@ def buildlib(bldroot, libroot, case, compname=None):
     use_unstruct = case.get_value("WW3_UNSTRUCT")
     if use_unstruct:
         cmake_flags += " -DUSE_UNSTRUCT=on "
+
+    waveprop = case.get_value("WW3_WAVEPROP")
+    if waveprop == 'PR3':
+        cmake_flags += " -DUSE_PR3=on "
+    elif waveprop == 'PR1':
+        cmake_flags += " -DUSE_PR1=on "
+    else:
+        expect(False,"ERROR only wave propagation type PR3 and PR1 are supported currently")
     cmake_flags += srcpath
 
     # run cmake

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -230,33 +230,6 @@ def buildnml(case, caseroot, compname):
             logger.debug("WW3 namelist copy: file1 %s file2 %s ", file1, file2)
             shutil.copy2(file1, file2)
 
-    #----------------------------------------------------
-    # Prestage necessary files to rundir
-    #----------------------------------------------------
-    rundir = case.get_value("RUNDIR")
-
-    # Copy ww3_inp and other needed info to ww3_moddef_dir
-    output_dir = os.path.join(rundir, "ww3_moddef_create")
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-
-    input_dir = case.get_value("WW3_GRID_INP_DIR")
-    files = os.listdir(input_dir)
-    for filename in files:
-        if not os.path.isfile(os.path.join(output_dir, filename)):
-            shutil.copy(os.path.join(input_dir, filename), os.path.join(output_dir, filename))
-
-    # If mod_def.ww3 is already in the directory - then use it
-    mod_def_user = os.path.join(rundir, "mod_def.ww3.user")
-    if os.path.isfile(mod_def_user):
-        shutil.copy(mod_def_user, os.path.join(rundir, "mod_def.ww3"))
-    else:
-        mod_def_in = case.get_value("WW3_MODDEF")
-        if os.path.isfile(mod_def_in):
-            shutil.copy(mod_def_in, os.path.join(rundir, "mod_def.ww3"))
-        else:
-            raise RuntimeError("mod_def_in {} does not exist on disk".format(mod_def_in))
-
 ###############################################################################
 def _main_func():
 ###############################################################################

--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -37,8 +37,22 @@ def _create_namelists(case, confdir, namelist_infile, nmlgen, data_list_path):
     config["runtype"] = run_type
     config["wav_grid"] = case.get_value("WAV_GRID")
 
+    rundir = case.get_value("RUNDIR")
+    start_date = case.get_value("RUN_STARTDATE")
+    start_date = start_date.replace("-","")
+    start_tod = case.get_value("START_TOD")
+
+    # determine coupling intervals
+    ncpl = case.get_value('WAV_NCPL')
+    if case.get_value('NCPL_BASE_PERIOD') == 'day':
+        basedt = 3600 * 24
+        dtime_sync = basedt // int(ncpl)
+    else:
+        expect(False,
+               'only day base period is supported for ww3 namelist generation')
+
     #----------------------------------------------------
-    # Initialize namelist defaults
+    # Write output namelist wav_in
     #----------------------------------------------------
     nmlgen.init_defaults(namelist_infile, config)
 
@@ -51,97 +65,32 @@ def _create_namelists(case, confdir, namelist_infile, nmlgen, data_list_path):
     else:
         nmlgen.add_default("initfile")
 
-    # Assume that ncpl base period is relative to a day
-    if case.get_value('NCPL_BASE_PERIOD') == 'day':
-        basedt = 3600 * 24
-    else:
-        expect(False,
-               'only day base period is supported for ww3 namelist generation')
-    ncpl = case.get_value('WAV_NCPL')
+    # error check 
     dtcpl = basedt / int(ncpl)
     dtmax = int(float(nmlgen.get_value('dtmax')))
     if dtcpl%dtmax != 0:
         expect(False,
                'dtcpl {} is not a multiple of dtmax {}'.format(dtcpl,dtmax))
 
+    nmlgen.set_value("domain_percent_start", f"{start_date} {start_tod}")
+
+    nmlgen.set_value("date_percent_field_percent_start"  , f"{start_date} {start_tod}")
+    nmlgen.set_value("date_percent_restart_percent_start", f"{start_date} {start_tod}")
+
+    nmlgen.set_value("date_percent_field_percent_stride"  , f"{dtime_sync}")
+    nmlgen.set_value("date_percent_restart_percent_stride", f"{dtime_sync}")
+
     # write diagnostic info
     logger.debug("ww3 initial conditions file is %s", nmlgen.get_value("initfile"))
 
-    #----------------------------------------------------
-    # Write output namelist wav_in
-    #----------------------------------------------------
     namelist_file = os.path.join(confdir, "wav_in")
-    nmlgen.write_output_file(namelist_file, data_list_path, groups=["ww3_inparm"])
+    nmlgen.write_output_file(namelist_file, data_list_path, 
+                             groups=["domain_nml","input_nml","output_type_nml","output_date_nml","ww3_inparm"], 
+                             sorted_groups=False)
 
-    #----------------------------------------------------
-    # Write output namelist ww3_shel.nml
-    #----------------------------------------------------
-
-    rundir = case.get_value("RUNDIR")
-    start_date = case.get_value("RUN_STARTDATE")
-    start_date = start_date.replace("-","")
-    start_tod = case.get_value("START_TOD")
-
-    # determine coupling intervals
-    ncpl = case.get_value("WAV_NCPL")
-    ncpl_base_period  = case.get_value('NCPL_BASE_PERIOD')
-    if ncpl_base_period == 'hour':
-        basedt = 3600
-    elif ncpl_base_period == 'day':
-        basedt = 3600 * 24
-    elif ncpl_base_period == 'year':
-        if case.get_value('CALENDAR') == 'NO_LEAP':
-            basedt = 3600 * 24 * 365
-        else:
-            expect(False, "Invalid CALENDAR for NCPL_BASE_PERIOD %s " %ncpl_base_period)
-    elif ncpl_base_period == 'decade':
-        if case.get_value('CALENDAR') == 'NO_LEAP':
-            basedt = 3600 * 24 * 365 * 10
-        else:
-            expect(False, "invalid NCPL_BASE_PERIOD NCPL_BASE_PERIOD %s " %ncpl_base_period)
-    else:
-        expect(False, "invalid NCPL_BASE_PERIOD NCPL_BASE_PERIOD %s " %ncpl_base_period)
-    dtime_sync = basedt // int(ncpl)
-
-    fnml = open(os.path.join(rundir, "ww3_shel.nml"), 'w', encoding="utf-8")
-
-    fnml.write(f"! Note that CESM restarts are not controlled by namelist input\n")
-    fnml.write(f"! - but rather by driver config variables\n")
-    fnml.write(f"! See w3nmlshelmd.F90 for the definition of the data types used below\n")
-
-    fnml.write(f"&domain_nml\n")
-    fnml.write(f" domain%start = '{start_date} {start_tod}'\n")
-    fnml.write(f" domain%stop  = '99990101 0'\n")
-    fnml.write(f"/\n")
-
-    fnml.write(f"&input_nml\n")
-    fnml.write(f"  input%forcing%water_levels = 'T'\n")
-    fnml.write(f"  input%forcing%currents     = 'T'\n")
-    fnml.write(f"  input%forcing%winds        = 'T'\n")
-    fnml.write(f"  input%forcing%ice_conc     = 'T'\n")
-    fnml.write(f"  input%forcing%ice_param1   = 'T'\n")
-    fnml.write(f"  input%forcing%ice_param5   = 'T'\n")
-    fnml.write(f"/\n")
-
-    fnml.write(f"&output_type_nml\n")
-    fnml.write(f"  type%field%list = 'WND ICE HS T02 T0M1 T01 FP DIR EF USS TOC'\n")
-    fnml.write(f"  type%point%file = 'points.list'\n")
-    fnml.write(f"/\n")
-
-    fnml.write(f"&output_date_nml\n")
-    fnml.write(f"  date%field%outffile  = '1'\n")
-    fnml.write(f"  date%field%start     = '{start_date} {start_tod}'\n")
-    fnml.write(f"  date%field%stride    = '{dtime_sync}'\n")
-    fnml.write(f"  date%field%stop      = '99990101 0'\n")
-    fnml.write(f"  date%restart%start   = '{start_date} {start_tod}'\n")
-    fnml.write(f"  date%restart%stride  = '{dtime_sync}'\n")
-    fnml.write(f"  date%restart%stop    = '99990101 0'\n")
-    fnml.write(f"  date%restart2%start  = '99990101 0'\n")
-    fnml.write(f"  date%restart2%stride = '0'\n")
-    fnml.write(f"  date%restart2%stop   = '99990101 0'\n")
-    fnml.write(f"/\n")
-
-    fnml.close()
+    from pathlib import Path
+    file = Path(namelist_file)
+    file.write_text(file.read_text().replace('_percent_', '%'))
 
 ###############################################################################
 def buildnml(case, caseroot, compname):

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -33,7 +33,7 @@
     <valid_values>PR1,PR3</valid_values>
     <default_value>PR3</default_value>
     <values>
-      <value grid="wtnx1v4nowall">PR1</value>
+      <value grid="wtnx1v4nw">PR1</value>
     </values>
     <group>case_comp</group>
     <file>env_build.xml</file>
@@ -46,10 +46,6 @@
     <values>
       <value grid="_w%gx1v7">$DIN_LOC_ROOT/wav/ww3/gx1v7.mod_def.ww3.wwver7.14.220506</value>
       <value grid="_w%wtx0.661v1">$DIN_LOC_ROOT/wav/ww3/wt061.mod_def.ww3.wwver7.14.220504</value>
-      <!-- <value grid="_w%wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.mod_def.ww3.230308</value> -->
-      <!-- <value grid="_w%wtnx1v4nowall" compset="%PR1">$DIN_LOC_ROOT/wav/ww3/wtnx1v4Nw_Pr1.mod_def.ww3.230621</value> -->
-      <!-- <value grid="_w%trip1degmask">$DIN_LOC_ROOT/wav/ww3/mod_def.trip1degmask</value> -->
-      <!-- <value grid="_w%wise.tnx1v4p.100k">$DIN_LOC_ROOT/wav/ww3/mod_def.wise.tnx1v4p.100k</value> -->
     </values>
     <group>case_comp</group>
     <file>env_build.xml</file>

--- a/cime_config/config_component.xml
+++ b/cime_config/config_component.xml
@@ -21,33 +21,48 @@
     <values>
       <value grid="_w%wise.tnx1v4p.100k">TRUE</value>
       <value grid="_w%tri1degmask">TRUE</value>
+      <value grid="_w%w025unstr">TRUE</value>
     </values>
     <group>case_comp</group>
-    <file>env_run.xml</file>
+    <file>env_build.xml</file>
     <desc>if TRUE, use the unstructured mesh configuration of WW3</desc>
+  </entry>
+
+  <entry id="WW3_WAVEPROP">
+    <type>char</type>
+    <valid_values>PR1,PR3</valid_values>
+    <default_value>PR3</default_value>
+    <values>
+      <value grid="wtnx1v4nowall">PR1</value>
+    </values>
+    <group>case_comp</group>
+    <file>env_build.xml</file>
+    <desc>Wave propagation scheme</desc>
   </entry>
 
   <entry id="WW3_MODDEF">
     <type>char</type>
     <default_value>unset</default_value>
     <values>
-      <value grid="_w%ww3a">$DIN_LOC_ROOT/wav/ww3/ww3a.mod_def.ww3.wwver7.14.220506</value>
       <value grid="_w%gx1v7">$DIN_LOC_ROOT/wav/ww3/gx1v7.mod_def.ww3.wwver7.14.220506</value>
       <value grid="_w%wtx0.661v1">$DIN_LOC_ROOT/wav/ww3/wt061.mod_def.ww3.wwver7.14.220504</value>
-      <value grid="_w%wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.mod_def.ww3.230308</value>
-      <value grid="_w%trip1degmask">$DIN_LOC_ROOT/wav/ww3/mod_def.trip1degmask</value>
-      <value grid="_w%wise.tnx1v4p.100k">$DIN_LOC_ROOT/wav/ww3/mod_def.wise.tnx1v4p.100k</value>
+      <!-- <value grid="_w%wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.mod_def.ww3.230308</value> -->
+      <!-- <value grid="_w%wtnx1v4nowall" compset="%PR1">$DIN_LOC_ROOT/wav/ww3/wtnx1v4Nw_Pr1.mod_def.ww3.230621</value> -->
+      <!-- <value grid="_w%trip1degmask">$DIN_LOC_ROOT/wav/ww3/mod_def.trip1degmask</value> -->
+      <!-- <value grid="_w%wise.tnx1v4p.100k">$DIN_LOC_ROOT/wav/ww3/mod_def.wise.tnx1v4p.100k</value> -->
     </values>
     <group>case_comp</group>
-    <file>env_run.xml</file>
-    <desc>mod_def file to use</desc>
+    <file>env_build.xml</file>
+    <desc>mod_def file to use. The value depends on the switches, if you have an unstructured mesh and the
+    wave propoagation scheme. Note that this file is renamed to mod_def.ww3 in the run directory.
+    </desc>
   </entry>
 
   <entry id="WW3_GRID_INP_DIR">
     <type>char</type>
     <default_value>$DIN_LOC_ROOT/wav/ww3/grid_inp.${WAV_GRID}</default_value>
     <group>case_comp</group>
-    <file>env_run.xml</file>
+    <file>env_build.xml</file>
     <desc>Directory where ww3_grid.inp and associated files can be
     found. This directory will normally be in the $DIN_LOC_ROOT/wav/ww3
     directory and have the name of the ww3 grid.</desc>

--- a/cime_config/config_compsets.xml
+++ b/cime_config/config_compsets.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+
+<compsets>
+
+  <help>
+    Each compset node is associated with the following elements
+    - lname      
+    - alias        
+    - support  (optional description of the support level for this compset)
+    Each compset node can also have the following attributes
+    - grid  (optional regular expression match for grid to work with the compset)
+  </help>
+
+  <compset>
+    <alias>WW3test</alias>   
+    <lname>2000_DATM%NYF_SLND_SICE_SOCN_SROF_SGLC_WW3DEV</lname>
+  </compset>
+
+</compsets>

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0"?>
+
+<config_pes>
+
+  <grid name="any">
+    <mach name="betzy">
+      <pes pesize="M" compset="DATM.*WW3DEV">
+	<comment>none</comment>
+	<ntasks>
+	  <ntasks_atm>256</ntasks_atm> 
+	  <ntasks_rof>256</ntasks_rof> 
+	  <ntasks_ice>256</ntasks_ice> 
+	  <ntasks_ocn>256</ntasks_ocn> 
+	  <ntasks_cpl>256</ntasks_cpl> 
+	  <ntasks_lnd>256</ntasks_lnd>
+	  <ntasks_glc>256</ntasks_glc> 
+	  <ntasks_wav>256</ntasks_wav> 
+	</ntasks>
+	<nthrds>
+	  <nthrds_atm>1</nthrds_atm>                   
+	  <nthrds_lnd>1</nthrds_lnd> 
+	  <nthrds_rof>1</nthrds_rof> 
+	  <nthrds_ice>1</nthrds_ice> 
+	  <nthrds_ocn>1</nthrds_ocn> 
+	  <nthrds_glc>1</nthrds_glc> 
+	  <nthrds_wav>1</nthrds_wav> 
+	  <nthrds_cpl>1</nthrds_cpl> 
+	</nthrds>
+	<rootpe>
+	  <rootpe_atm>0</rootpe_atm> 
+	  <rootpe_lnd>0</rootpe_lnd> 
+	  <rootpe_rof>0</rootpe_rof> 
+	  <rootpe_ice>0</rootpe_ice>    
+	  <rootpe_ocn>0</rootpe_ocn>   
+	  <rootpe_glc>0</rootpe_glc> 
+	  <rootpe_wav>0</rootpe_wav> 
+	  <rootpe_cpl>0</rootpe_cpl>                         
+	</rootpe>
+      </pes>
+    </mach>
+  </grid>
+
+</config_pes>

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -192,12 +192,100 @@
       <value>T</value>
     </values>
   </entry>
+  <entry id="input_percent_forcing_percent_ice_param2">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_ice_param3">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_ice_param4">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
   <entry id="input_percent_forcing_percent_ice_param5">
     <type>char</type>
     <group>input_nml</group>
     <category>setup</category>
     <values>
       <value>T</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_atm_momentum">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_air_density">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_mud_density">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_mud_thickness">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_mud_viscosity">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_assim_mean">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_assim_spec1d">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
+    </values>
+  </entry>
+  <entry id="input_assim_spec2d">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>F</value>
     </values>
   </entry>
 

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -135,4 +135,170 @@
     </desc>
   </entry>
 
+  <entry id='domain_percent_start'>
+    <type>char</type>
+    <group>domain_nml</group>
+    <category>setup</category>
+    <values>
+      <value>unset</value>
+    </values>
+  </entry>
+  <entry id="domain_percent_stop">
+    <type>char</type>
+    <group>domain_nml</group>
+    <category>setup</category>
+    <values>
+      <value>'99990101 0'</value>
+    </values>
+  </entry>
+
+  <entry id="input_percent_forcing_percent_water_levels">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>T</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_currents">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>T</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_winds">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>T</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_ice_conc">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>T</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_ice_param1">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>T</value>
+    </values>
+  </entry>
+  <entry id="input_percent_forcing_percent_ice_param5">
+    <type>char</type>
+    <group>input_nml</group>
+    <category>setup</category>
+    <values>
+      <value>T</value>
+    </values>
+  </entry>
+
+  <entry id="type_percent_field_percent_list">
+    <type>char</type>
+    <group>output_type_nml</group>
+    <category>setup</category>
+    <values>
+      <value>WND ICE HS T02 T0M1 T01 FP DIR EF USS TOC</value>
+    </values>
+  </entry>
+  <entry id="type_percent_point_percent_file">
+    <type>char</type>
+    <group>output_type_nml</group>
+    <category>setup</category>
+    <values>
+      <value>points.list</value>
+    </values>
+  </entry>
+
+  <entry id="date_percent_field_percent_outffile">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>1</value>
+    </values>
+  </entry>
+  <entry id="date_percent_field_percent_start">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>unset</value>
+    </values>
+  </entry>
+  <entry id="date_percent_field_percent_stride">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>unset</value>
+    </values>
+  </entry>
+  <entry id="date_percent_field_percent_stop">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>99990101 0</value>
+    </values>
+  </entry>
+
+  <entry id="date_percent_restart_percent_start">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>unset</value>
+    </values>
+  </entry>
+  <entry id="date_percent_restart_percent_stride">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>unset</value>
+    </values>
+  </entry>
+  <entry id="date_percent_restart_percent_stop">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>99990101 0</value>
+    </values>
+  </entry>
+
+  <entry id="date_percent_restart2_percent_start">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>99990101 0</value>
+    </values>
+  </entry>
+  <entry id="date_percent_restart2_percent_stride">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>0</value>
+    </values>
+  </entry>
+  <entry id="date_percent_restart2_percent_stop">
+    <type>char</type>
+    <group>output_date_nml</group>
+    <category>setup</category>
+    <values>
+      <value>99990101 0</value>
+    </values>
+  </entry>
+
 </entry_id>

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -264,7 +264,7 @@
       <value>F</value>
     </values>
   </entry>
-  <entry id="input_assim_mean">
+  <entry id="input_percent_assim_percent_mean">
     <type>char</type>
     <group>input_nml</group>
     <category>setup</category>
@@ -272,7 +272,7 @@
       <value>F</value>
     </values>
   </entry>
-  <entry id="input_assim_spec1d">
+  <entry id="input_percent_assim_percent_spec1d">
     <type>char</type>
     <group>input_nml</group>
     <category>setup</category>
@@ -280,7 +280,7 @@
       <value>F</value>
     </values>
   </entry>
-  <entry id="input_assim_spec2d">
+  <entry id="input_percent_assim_percent_spec2d">
     <type>char</type>
     <group>input_nml</group>
     <category>setup</category>

--- a/cime_config/namelist_definition_ww3.xml
+++ b/cime_config/namelist_definition_ww3.xml
@@ -43,6 +43,8 @@
       <value runtype="hybrid"	wav_grid="wtx0.66v1">$DIN_LOC_ROOT/wav/ww3/wt061.restart.ww3.calm.wwver7.14.220110</value>
       <value runtype="startup"	wav_grid="wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.restart.ww3.230308</value>
       <value runtype="hybrid"	wav_grid="wtnx1v4">$DIN_LOC_ROOT/wav/ww3/wtnx1v4.restart.ww3.230308</value>
+      <value runtype="startup"	wav_grid="wtnx1v4nw">' '</value>
+      <value runtype="hybrid"	wav_grid="wtnx1v4nw">' '</value>
     </values>
     <desc>
       Initial condition file.
@@ -88,6 +90,7 @@
       <value wav_grid="gx1v7">1800.</value>
       <value wav_grid="wtx0.66v1">1200.</value>
       <value wav_grid="wtnx1v4">1800.</value>
+      <value wav_grid="w025">1200.</value>
     </values>
     <desc>
       Maximum overall time step
@@ -103,6 +106,7 @@
       <value wav_grid="gx1v7">900.</value>
       <value wav_grid="wtx0.66v1">600.</value>
       <value wav_grid="wtnx1v4">900.</value>
+      <value wav_grid="w025">600.</value>
     </values>
     <desc>
       Maximum CFL time step X-Y propagation.
@@ -118,6 +122,7 @@
       <value wav_grid="gx1v7">900.</value>
       <value wav_grid="wtx0.66v1">600.</value>
       <value wav_grid="wtnx1v4">900.</value>
+      <value wav_grid="w025">600.</value>
     </values>
     <desc>
       Id. intra-spectral

--- a/cime_config/testdefs/testlist_ww3dev.xml
+++ b/cime_config/testdefs/testlist_ww3dev.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS_D_P256" grid="T62_wtn14" compset="WW3test">
+  <test name="PFS" grid="T62_wtn14nw" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
@@ -8,7 +8,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5_P256" grid="T62_wtn14nw" compset="WW3test">
+  <test name="ERS_D_Ld5" grid="T62_wtn14" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
@@ -16,7 +16,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5_P256" grid="T62_wtn14" compset="WW3test">
+  <test name="ERS_D_Ld5" grid="T62_wtn14nw" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
@@ -24,15 +24,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5_P256" grid="T62_wtn14nw" compset="WW3test">
-    <machines>
-      <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
-    </machines>
-    <options>
-      <option name="wallclock">01:00:00</option>
-    </options>
-  </test>
-  <test name="ERS_Ld5_P256" grid="T62_w025" compset="WW3test">
+  <test name="ERS_D_Ld5" grid="T62_w025" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>

--- a/cime_config/testdefs/testlist_ww3dev.xml
+++ b/cime_config/testdefs/testlist_ww3dev.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS_D_Ld3" grid="T62_tn14_wtn14" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
+  <test name="SMS_D_P256" grid="T62_wtn14" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
@@ -8,7 +8,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="T62_tn14_wtn14" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
+  <test name="ERS_Ld5_P256" grid="T62_wtn14nw" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
@@ -16,7 +16,7 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="T62_tn14_wtn14nw" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
+  <test name="ERS_Ld5_P256" grid="T62_wtn14" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
@@ -24,7 +24,15 @@
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS_Ld5" grid="T62_tn14_w025us" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
+  <test name="ERS_Ld5_P256" grid="T62_wtn14nw" compset="WW3test">
+    <machines>
+      <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
+    </machines>
+    <options>
+      <option name="wallclock">01:00:00</option>
+    </options>
+  </test>
+  <test name="ERS_Ld5_P256" grid="T62_w025" compset="WW3test">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>

--- a/cime_config/testdefs/testlist_ww3dev.xml
+++ b/cime_config/testdefs/testlist_ww3dev.xml
@@ -1,35 +1,35 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
-  <test name="SMS_D" grid="TL319_t061" compset="GMOM_JRA_WD">
+  <test name="SMS_D_Ld3" grid="T62_tn14_wtn14" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS" grid="TL319_t061_wt061" compset="GMOM_JRA_WD">
+  <test name="ERS_Ld5" grid="T62_tn14_wtn14" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
     <options>
       <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS" grid="T62_g17" compset="2000_DATM%NYF_SLND_DICE%SSMI_POP2_DROF%NYF_SGLC_WW3DEV">
+  <test name="ERS_Ld5" grid="T62_tn14_wtn14nw" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">01:00:00</option>
     </options>
   </test>
-  <test name="ERS" grid="T62_g17" compset="2000_DATM%NYF_SLND_CICE_POP2_DROF%NYF_SGLC_WW3DEV">
+  <test name="ERS_Ld5" grid="T62_tn14_w025us" compset="2000_DATM%NYF_SLND_CICE_BLOM_DROF%NYF_SGLC_WW3DEV">
     <machines>
-      <machine name="cheyenne" compiler="intel" category="aux_ww3dev"/>
+      <machine name="betzy" compiler="intel" category="aux_ww3dev_noresm"/>
     </machines>
     <options>
-      <option name="wallclock">00:30:00</option>
+      <option name="wallclock">01:00:00</option>
     </options>
   </test>
 </testlist>

--- a/cime_config/user_nl_ww3dev
+++ b/cime_config/user_nl_ww3dev
@@ -2,4 +2,31 @@
 ! Users should add all user specific namelist changes below in the form of
 !   namelist_var = new_namelist_value
 ! Note - that it does not matter what namelist group the namelist_var belongs to
+! The following namelist variables that contain % must bespecified keywords that
+! replace the % with _percent_
+! the following translations will then occur when the namelist is generated
+!
+! domain_percent_start =>  domain%start
+! domain_percent_stop  =>  domain%stop
+!
+! input_percent_forcing_percent_water_levels=>  input%forcing%water_levels
+! input_percent_forcing_percent_currents    =>  input%forcing%currents
+! input_percent_forcing_percent_winds	    =>  input%forcing%winds
+! input_percent_forcing_percent_ice_conc    =>  input%forcing%ice_conc
+! input_percent_forcing_percent_ice_param1  =>  input%forcing%ice_param1
+! input_percent_forcing_percent_ice_param5  =>  input%forcing%ice_param5
+! 
+! type_percent_field_percent_list =>  type%field%list
+! type_percent_point_percent_file =>  type%point%file
+! 
+! date_percent_field_percent_outffile =>  date%field%outffile
+! date_percent_field_percent_start    =>  date%field%start
+! date_percent_field_percent_stride   =>  date%field%stride
+! date_percent_field_percent_stop     =>  date%field%stop
+! date_percent_restart_percent_start  =>  date%restart%start
+! date_percent_restart_percent_stride =>  date%restart%stride
+! date_percent_restart_percent_stop   =>  date%restart%stop
+! date_percent_restart2_percent_start =>  date%restart2%start
+! date_percent_restart2_percent_strid =>  date%restart2%stride
+! date_percent_restart2_percent_stop  =>  date%restart2%stop
 !----------------------------------------------------------------------------------


### PR DESCRIPTION
This PR does the following:
- creates a unified namelist (wav_in) that merges the namelist previously used in ww3_shel.nml and thereby permits the user
to change the shel namelists with keyword/value syntax
- always creates a moddef file upon issuing case.build - the input for the moddef creation (executable ww3_grid) is found in $DIN_LOC_ROOT/wav/ww3/grid.$WAV_GRID
As a result of this feature - no new wave moddef file needs to be created
- addition of new compset WW3test (using only DATM and WWDEV)
- addition of new regression tests for WW3DEV utilizing the compset WW3test